### PR TITLE
Piper/fix get accounts

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+0.2.0
+-----
+
+- Python 3 Compatability
+
 0.1.1
 -----
 

--- a/eth_tester_client/client.py
+++ b/eth_tester_client/client.py
@@ -189,7 +189,7 @@ class EthTesterClient(object):
 
     def get_accounts(self):
         return [
-            encode_32bytes(addr) for addr in t.accounts
+            encode_address(addr) for addr in t.accounts
         ]
 
     def get_code(self, address, block_number="latest"):

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup
 
 DIR = os.path.dirname(os.path.abspath(__file__))
 
-version = '0.1.1'
+version = '0.2.0'
 
 readme = open(os.path.join(DIR, 'README.md')).read()
 
@@ -23,7 +23,7 @@ setup(
     include_package_data=True,
     py_modules=['eth_tester-client'],
     install_requires=[
-        "ethereum>=1.0.6",
+        "ethereum>=1.3.6",
         "serpent",
     ],
     license="MIT",

--- a/tests/client/test_get_accounts.py
+++ b/tests/client/test_get_accounts.py
@@ -1,0 +1,2 @@
+def test_get_accounts(client, accounts):
+    assert client.get_accounts() == accounts


### PR DESCRIPTION
Fix `tester.get_accounts()` to return proper length account strings.