### PR TITLE
Piper/implement personal apis

### DIFF
--- a/eth_tester_client/client.py
+++ b/eth_tester_client/client.py
@@ -27,6 +27,7 @@ from .utils import (
     normalize_address,
     decode_hex,
     mk_random_privkey,
+    coerce_args_to_bytes,
 )
 from .serializers import (
     serialize_txn,
@@ -305,6 +306,7 @@ class EthTesterClient(object):
         self.unlocked_accounts.pop(address, None)
         return True
 
+    @coerce_args_to_bytes
     def check_passphrase(self, address, passphrase):
         address = normalize_address(address)
         if address not in self.passphrase_accounts:
@@ -314,7 +316,8 @@ class EthTesterClient(object):
         else:
             return False
 
-    def unlocked_account(self, address, passphrase, duration=None):
+    @coerce_args_to_bytes
+    def unlock_account(self, address, passphrase, duration=None):
         address = normalize_address(address)
         if self.check_passphrase(address, passphrase):
             if duration is not None:
@@ -325,6 +328,7 @@ class EthTesterClient(object):
             return True
         return False
 
+    @coerce_args_to_bytes
     def import_raw_key(self, private_key, passphrase):
         if not passphrase:
             raise ValueError("Cannot have empty passphrase")
@@ -336,11 +340,13 @@ class EthTesterClient(object):
 
         return encode_address(public_key)
 
+    @coerce_args_to_bytes
     def new_account(self, passphrase):
         private_key = mk_random_privkey()
 
         return self.import_raw_key(private_key, passphrase)
 
+    @coerce_args_to_bytes
     def send_and_sign_transaction(self, passphrase, **txn_kwargs):
         try:
             _from = txn_kwargs['_from']
@@ -350,7 +356,7 @@ class EthTesterClient(object):
         _from = normalize_address(_from)
 
         try:
-            self.unlocked_account(_from, passphrase)
+            self.unlock_account(_from, passphrase)
             return self.send_transaction(**txn_kwargs)
         finally:
             self.lock_account(_from)

--- a/eth_tester_client/client.py
+++ b/eth_tester_client/client.py
@@ -13,7 +13,6 @@ import rlp
 
 from ethereum import transactions
 from ethereum import tester as t
-from ethereum import keys
 from ethereum.utils import (
     privtoaddr,
 )

--- a/eth_tester_client/client.py
+++ b/eth_tester_client/client.py
@@ -27,7 +27,6 @@ from .utils import (
     normalize_address,
     decode_hex,
     mk_random_privkey,
-    coerce_args_to_bytes,
 )
 from .serializers import (
     serialize_txn,

--- a/eth_tester_client/utils.py
+++ b/eth_tester_client/utils.py
@@ -186,4 +186,4 @@ def decode_hex(value):
 
 
 def mk_random_privkey():
-    return decode_hex(hex(random.getrandbits(256)))
+    return decode_hex(encode_number(random.getrandbits(256), 32))

--- a/eth_tester_client/utils.py
+++ b/eth_tester_client/utils.py
@@ -1,5 +1,6 @@
 import sys
 import functools
+import random
 
 from rlp.utils import (
     int_to_big_endian,
@@ -182,3 +183,7 @@ def encode_number(value, length=None):
 @coerce_args_to_bytes
 def decode_hex(value):
     return _decode_hex(strip_0x(value))
+
+
+def mk_random_privkey():
+    return decode_hex(hex(random.getrandbits(256)))

--- a/tests/client/test_account_management_api.py
+++ b/tests/client/test_account_management_api.py
@@ -3,25 +3,24 @@ from eth_tester_client.utils import mk_random_privkey
 
 
 def test_import_raw_key(client):
-    pk = mk_random_privkey
+    pk = mk_random_privkey()
 
-    assert pk not in tester.keys
+    initial_accounts = client.get_accounts()
 
-    client.import_raw_key(pk)
+    address = client.import_raw_key(pk, 'some-password')
 
-    assert pk in tester.keys
+    assert address not in initial_accounts
+    assert address in client.get_accounts()
 
 
 def test_new_account(client):
-    prev_account_list = client.accounts
+    initial_accounts = client.get_accounts()
 
     address = client.new_account("some-password")
 
-    updated_account_list = client.accounts
-
     assert address
-    assert address not in prev_account_list
-    assert address in updated_account_list
+    assert address not in initial_accounts
+    assert address in client.get_accounts()
 
     assert not client.unlocked_account(address, "wrong-password")
     assert client.unlocked_account(address, "some-password")

--- a/tests/client/test_account_management_api.py
+++ b/tests/client/test_account_management_api.py
@@ -1,0 +1,43 @@
+from ethereum import tester
+from eth_tester_client.utils import mk_random_privkey
+
+
+def test_import_raw_key(client):
+    pk = mk_random_privkey
+
+    assert pk not in tester.keys
+
+    client.import_raw_key(pk)
+
+    assert pk in tester.keys
+
+
+def test_new_account(client):
+    prev_account_list = client.accounts
+
+    address = client.new_account("some-password")
+
+    updated_account_list = client.accounts
+
+    assert address
+    assert address not in prev_account_list
+    assert address in updated_account_list
+
+    assert not client.unlocked_account(address, "wrong-password")
+    assert client.unlocked_account(address, "some-password")
+
+
+def test_cannot_send_with_locked_account(client):
+    assert False
+
+
+def test_send_with_unlocked_account(client):
+    assert False
+
+
+def test_locking_an_unlocked_account(client):
+    assert False
+
+
+def test_unlock_with_duration(client):
+    assert False

--- a/tests/client/test_account_management_api.py
+++ b/tests/client/test_account_management_api.py
@@ -1,3 +1,6 @@
+import time
+import pytest
+
 from ethereum import tester
 from eth_tester_client.utils import mk_random_privkey
 
@@ -26,17 +29,95 @@ def test_new_account(client):
     assert client.unlocked_account(address, "some-password")
 
 
-def test_cannot_send_with_locked_account(client):
-    assert False
+def test_cannot_send_with_locked_account(client, accounts):
+    sender = client.new_account("some-password")
+
+    amt = 1000000000000
+
+    # fund account
+    client.send_transaction(_from=accounts[0], to=sender, value=amt)
+    balance = client.get_balance(sender)
+    assert balance >= amt
+
+    with pytest.raises(ValueError):
+        client.send_transaction(_from=sender, to=accounts[1], value=12345)
+
+    # ensure balance didn't change
+    assert balance == client.get_balance(sender)
 
 
-def test_send_with_unlocked_account(client):
-    assert False
+def test_send_with_unlocked_account(client, accounts):
+    sender = client.new_account("some-password")
+
+    # fund account
+    amt = 1000000000000
+    client.send_transaction(_from=accounts[0], to=sender, value=amt)
+    assert client.get_balance(sender) >= amt
+
+    assert client.unlocked_account(sender, "some-password")
+
+    before_bal = client.get_balance(accounts[1])
+
+    client.send_transaction(_from=sender, to=accounts[1], value=12345)
+
+    after_bal = client.get_balance(accounts[1])
+
+    assert after_bal == before_bal + 12345
 
 
-def test_locking_an_unlocked_account(client):
-    assert False
+def test_locking_an_unlocked_account(client, accounts):
+    sender = client.new_account("some-password")
+
+    # fund account
+    amt = 1000000000000
+    client.send_transaction(_from=accounts[0], to=sender, value=amt)
+    assert client.get_balance(sender) >= amt
+
+    assert client.unlocked_account(sender, "some-password")
+
+    client.send_transaction(_from=sender, to=accounts[1], value=12345)
+
+    assert client.lock_account(sender)
+
+    with pytest.raises(ValueError):
+        client.send_transaction(_from=sender, to=accounts[1], value=12345)
 
 
-def test_unlock_with_duration(client):
-    assert False
+def test_unlock_with_duration(client, accounts):
+    sender = client.new_account("some-password")
+
+    # fund account
+    amt = 1000000000000
+    client.send_transaction(_from=accounts[0], to=sender, value=amt)
+    assert client.get_balance(sender) >= amt
+
+    assert client.unlocked_account(sender, "some-password", 1)
+
+    client.send_transaction(_from=sender, to=accounts[1], value=12345)
+
+    time.sleep(1)
+
+    with pytest.raises(ValueError):
+        client.send_transaction(_from=sender, to=accounts[1], value=12345)
+
+
+def test_send_and_sign_transaction(client, accounts):
+    sender = client.new_account("some-password")
+
+    # fund account
+    amt = 1000000000000
+    client.send_transaction(_from=accounts[0], to=sender, value=amt)
+    assert client.get_balance(sender) >= amt
+
+    before_bal = client.get_balance(accounts[1])
+
+    client.send_and_sign_transaction(
+        "some-password",
+        _from=sender,
+        to=accounts[1],
+        value=12345,
+    )
+
+    after_bal = client.get_balance(accounts[1])
+
+    assert after_bal == before_bal + 12345

--- a/tests/client/test_account_management_api.py
+++ b/tests/client/test_account_management_api.py
@@ -25,8 +25,8 @@ def test_new_account(client):
     assert address not in initial_accounts
     assert address in client.get_accounts()
 
-    assert not client.unlocked_account(address, "wrong-password")
-    assert client.unlocked_account(address, "some-password")
+    assert not client.unlock_account(address, "wrong-password")
+    assert client.unlock_account(address, "some-password")
 
 
 def test_cannot_send_with_locked_account(client, accounts):
@@ -54,7 +54,7 @@ def test_send_with_unlocked_account(client, accounts):
     client.send_transaction(_from=accounts[0], to=sender, value=amt)
     assert client.get_balance(sender) >= amt
 
-    assert client.unlocked_account(sender, "some-password")
+    assert client.unlock_account(sender, "some-password")
 
     before_bal = client.get_balance(accounts[1])
 
@@ -73,7 +73,7 @@ def test_locking_an_unlocked_account(client, accounts):
     client.send_transaction(_from=accounts[0], to=sender, value=amt)
     assert client.get_balance(sender) >= amt
 
-    assert client.unlocked_account(sender, "some-password")
+    assert client.unlock_account(sender, "some-password")
 
     client.send_transaction(_from=sender, to=accounts[1], value=12345)
 
@@ -91,7 +91,7 @@ def test_unlock_with_duration(client, accounts):
     client.send_transaction(_from=accounts[0], to=sender, value=amt)
     assert client.get_balance(sender) >= amt
 
-    assert client.unlocked_account(sender, "some-password", 1)
+    assert client.unlock_account(sender, "some-password", 1)
 
     client.send_transaction(_from=sender, to=accounts[1], value=12345)
 

--- a/tests/utility/test_priv_key_generation.py
+++ b/tests/utility/test_priv_key_generation.py
@@ -1,0 +1,7 @@
+from eth_tester_client.utils import mk_random_privkey
+
+
+def test_priv_key_generation():
+    for i in range(100):
+        pk = mk_random_privkey()
+        assert len(pk) == 32


### PR DESCRIPTION
### What was wrong?

The [`personal` apis](https://github.com/ethereum/go-ethereum/wiki/Management-APIs#personal) were not implemented which prevented implementing them in things like `eth-testrpc` client.

### How was it fixed?

Added them.

#### Cute Animal Picture

> put a cute animal picture here.

![infant-giraffe](https://cloud.githubusercontent.com/assets/824194/16500922/10cbd20c-3ec4-11e6-9b82-6fcea129fa8e.jpg)
