### PR TITLE
Switch to gevent for request thread

### DIFF
--- a/eth_tester_client/__init__.py
+++ b/eth_tester_client/__init__.py
@@ -1,5 +1,8 @@
 import pkg_resources
 
+from gevent import monkey
+monkey.patch_all()
+
 from .client import EthTesterClient  # NOQA
 
 

--- a/eth_tester_client/client.py
+++ b/eth_tester_client/client.py
@@ -6,8 +6,9 @@ https://github.com/ConsenSys/eth-testrpc
 """
 import sys
 import time
-import threading
 import uuid
+
+import gevent
 
 import rlp
 
@@ -65,9 +66,7 @@ class EthTesterClient(object):
             self.request_queue = Queue()
             self.results = {}
 
-            self.request_thread = threading.Thread(target=self.process_requests)
-            self.request_thread.daemon = True
-            self.request_thread.start()
+            self.request_thread = gevent.spawn(self.process_requests)
 
         self.passphrase_accounts = {}
         self.passphrase_account_keys = {}
@@ -233,6 +232,7 @@ class EthTesterClient(object):
                     if isinstance(result, Exception):
                         raise result
                     return encode_data(result)
+                gevent.sleep(0.1)
             raise ValueError("Timeout waiting for {0}".format(request_id))
         else:
             self._send_transaction(*args, **kwargs)

--- a/eth_tester_client/client.py
+++ b/eth_tester_client/client.py
@@ -227,12 +227,12 @@ class EthTesterClient(object):
             self.request_queue.put((request_id, args, kwargs))
             start = time.time()
             while time.time() - start < self.async_timeout:
+                gevent.sleep(0.1)
                 if request_id in self.results:
                     result = self.results.pop(request_id)
                     if isinstance(result, Exception):
                         raise result
                     return encode_data(result)
-                gevent.sleep(0.1)
             raise ValueError("Timeout waiting for {0}".format(request_id))
         else:
             self._send_transaction(*args, **kwargs)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 ethereum>=1.0.6
+gevent>=1.1.1

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
     py_modules=['eth_tester-client'],
     install_requires=[
         "ethereum>=1.3.6",
+        "gevent>=1.1.1",
     ],
     license="MIT",
     zip_safe=False,

--- a/tests/async/test_ethtester_async.py
+++ b/tests/async/test_ethtester_async.py
@@ -1,5 +1,5 @@
 import pytest
-import threading
+import gevent
 
 from ethereum import tester
 from ethereum import utils
@@ -26,9 +26,7 @@ def test_async_requests():
                 pytest.fail(''.join(e.args))
 
     for i in range(5):
-        thread = threading.Thread(target=spam_block_number)
-        thread.daemon = True
-        threads.append(thread)
+        thread = gevent.spawn(spam_block_number)
 
     [thread.start() for thread in threads]
 

--- a/tests/async/test_ethtester_async.py
+++ b/tests/async/test_ethtester_async.py
@@ -28,8 +28,6 @@ def test_async_requests():
     for i in range(5):
         thread = gevent.spawn(spam_block_number)
 
-    [thread.start() for thread in threads]
-
     [thread.join() for thread in threads]
 
     assert not errors


### PR DESCRIPTION
### What was wrong?

The stdlib threading module isn't playing nicely with other async code.

### How was it fixed?

Changed to use `gevent`

#### Cute Animal Picture

> put a cute animal picture here.

![btww5zw](https://cloud.githubusercontent.com/assets/824194/16504462/4f80f8e0-3ed5-11e6-85a7-cedb2384812c.jpg)
