### PR TITLE
bugfix for issue where the latest block would get out of sync during …

### DIFF
--- a/eth_tester_client/client.py
+++ b/eth_tester_client/client.py
@@ -101,14 +101,15 @@ class EthTesterClient(object):
             raise ValueError("No snapshots to revert to")
 
         if snapshot_idx is not None:
-            block_number, snapshot = self.snapshots[snapshot_idx]
+            block_number, snapshot = self.snapshots.pop(snapshot_idx)
         else:
             block_number, snapshot = self.snapshots.pop()
 
         # Remove all blocks after our saved block number.
-        del self.evm.blocks[block_number + 1:]
+        del self.evm.blocks[block_number:]
 
         self.evm.revert(snapshot)
+        self.evm.blocks.append(self.evm.block)
 
     def mine_block(self):
         self.evm.mine()


### PR DESCRIPTION
### What was wrong?

There is an infuriating bug that I think this fixes where in certain situations that I've never been able to reliably reproduce in this repository but always cropped up in my other codebases.

The latest block `client.evm.block` and the head block in `client.evm.blocks` would get out of sync after some combination of `client.call` and `client.revert` calls.

### How was it fixed?

Force the head block to be equal to `client.evm.block` when resetting.

#### Cute Animal Picture

> put a cute animal picture here.

![september-07-2012-20-25-07-asjdhkfjhwe](https://cloud.githubusercontent.com/assets/824194/17389122/8be0aeee-59be-11e6-85a0-41cf57d0d90d.jpg)
