### PR TITLE
Remove threading in favor of locking

### DIFF
--- a/tests/async/test_ethtester_async.py
+++ b/tests/async/test_ethtester_async.py
@@ -8,7 +8,7 @@ from eth_tester_client import EthTesterClient
 
 
 def test_async_requests():
-    client = EthTesterClient(async=True, async_timeout=60)
+    client = EthTesterClient()
 
     threads = []
     errors = []

--- a/tests/client/test_call.py
+++ b/tests/client/test_call.py
@@ -52,7 +52,6 @@ CONTRACT_SOURCE = (
 
 
 def test_eth_call(client, accounts):
-    client.is_async = False
     txn_hash = client.send_transaction(
         _from=accounts[0],
         data=CONTRACT_BIN,

--- a/tests/client/test_get_code.py
+++ b/tests/client/test_get_code.py
@@ -43,7 +43,6 @@ CONTRACT_SOURCE = (
 
 
 def test_get_code(client, accounts):
-    client.is_async = False
     txn_hash = client.send_transaction(
         _from=accounts[0],
         data=CONTRACT_BIN,

--- a/tests/filters/conftest.py
+++ b/tests/filters/conftest.py
@@ -101,7 +101,6 @@ def EMITTER_ABI():
 
 @pytest.fixture()
 def emitter_contract_address(client, accounts, EMITTER_CODE):
-    client.is_async = False
     txn_hash = client.send_transaction(
         _from=accounts[0],
         data=EMITTER_CODE,
@@ -115,8 +114,6 @@ def emitter_contract_address(client, accounts, EMITTER_CODE):
 
 @pytest.fixture()
 def call_emitter_contract(client, accounts, emitter_contract_address):
-    client.is_async = False
-
     def _call_emitter_contract(method_signature, arguments=None):
         if arguments is None:
             arguments = []


### PR DESCRIPTION
### What was wrong?

Instantiation of an `EthTesterClient` instance implicitely launched a thread.  This pattern was originally to support asynchronous calling of client methods.  This `gevent.spawn` call causes problems elsewhere.

### How was it fixed?

Removed the threading in favor of a lock.

#### Cute Animal Picture

> put a cute animal picture here.

![dexter_with_bird](https://cloud.githubusercontent.com/assets/824194/18106315/71ad439a-6ec0-11e6-8ba9-c013a77325ae.jpg)
