### PR TITLE
Fix off-by-one issues with filters and comparison types

### DIFF
--- a/eth_tester_client/client.py
+++ b/eth_tester_client/client.py
@@ -469,6 +469,8 @@ class EthTesterClient(object):
             filter_topics=log_filter['topics'],
         )
 
-        return list(itertools.chain.from_iterable((
+        all_log_entries = list(itertools.chain.from_iterable((
             block_processor_fn(block) for block in self.evm.blocks[block_slice]
         )))
+
+        return all_log_entries

--- a/eth_tester_client/filters.py
+++ b/eth_tester_client/filters.py
@@ -67,13 +67,15 @@ def check_if_topics_match(filter_topics, log_topics):
 @coerce_args_to_bytes
 def check_if_log_matches(log_entry, from_block, to_block,
                          addresses, filter_topics):
+    log_block_number = int(log_entry['blockNumber'], 16)
+
     #
     # validate `from_block` (left bound)
     #
     if is_string(from_block):
         pass
     elif is_numeric(from_block):
-        if from_block > log_entry['blockNumber']:
+        if from_block > log_block_number:
             return False
     else:
         raise TypeError("Invalid `from_block`")
@@ -84,7 +86,7 @@ def check_if_log_matches(log_entry, from_block, to_block,
     if is_string(to_block):
         pass
     elif is_numeric(to_block):
-        if to_block < log_entry['blockNumber']:
+        if to_block < log_block_number:
             return False
     else:
         raise TypeError("Invalid `to_block`")
@@ -150,6 +152,6 @@ def get_filter_bounds(from_block, to_block, bookmark=None):
     elif to_block == "pending":
         right_bound = None
     else:
-        right_bound = to_block
+        right_bound = to_block + 1
 
     return slice(left_bound, right_bound)

--- a/tests/filters/test_filter_log_matching.py
+++ b/tests/filters/test_filter_log_matching.py
@@ -56,6 +56,9 @@ def make_log_entry(block_number=1,
     (
         (make_log_filter(), make_log_entry(), True),
         (make_log_filter(), make_log_entry(topics=['a']), True),
+        (make_log_filter(from_block=1, to_block=2), make_log_entry(block_number=1), True),
+        (make_log_filter(from_block=1, to_block=2), make_log_entry(block_number=2), True),
+        (make_log_filter(from_block=1, to_block=2), make_log_entry(block_number=3), False),
     ),
 )
 def test_check_if_filter_matches_log(log_filter, log_entry, expected):


### PR DESCRIPTION
### What was wrong?

The utility functions surrounding filters were broken, trying to compare integers and hex-represented integers.

### How was it fixed?

* fixed an off-by-one error
* converted the hex block number to an integer prior to comparison.

#### Cute Animal Picture

> put a cute animal picture here.

![favim com-12182](https://cloud.githubusercontent.com/assets/824194/18212358/130d3bfa-7100-11e6-95af-9b1fb3623c64.jpg)
