### PR TITLE
Fix small errors in filter API

### DIFF
--- a/eth_tester_client/client.py
+++ b/eth_tester_client/client.py
@@ -366,7 +366,7 @@ class EthTesterClient(object):
 
     log_filters = None
 
-    def new_filter(self, from_block="latest", to_block="latest", address=None, topics=None):
+    def new_filter(self, from_block=None, to_block=None, address=None, topics=None):
         if topics is None:
             topics = []
 

--- a/eth_tester_client/filters.py
+++ b/eth_tester_client/filters.py
@@ -72,7 +72,7 @@ def check_if_log_matches(log_entry, from_block, to_block,
     #
     # validate `from_block` (left bound)
     #
-    if is_string(from_block):
+    if from_block is None or is_string(from_block):
         pass
     elif is_numeric(from_block):
         if from_block > log_block_number:
@@ -83,7 +83,7 @@ def check_if_log_matches(log_entry, from_block, to_block,
     #
     # validate `to_block` (left bound)
     #
-    if is_string(to_block):
+    if to_block is None or is_string(to_block):
         pass
     elif is_numeric(to_block):
         if to_block < log_block_number:
@@ -136,6 +136,8 @@ def process_block(block, from_block, to_block, addresses, filter_topics):
 def get_filter_bounds(from_block, to_block, bookmark=None):
     if bookmark is not None:
         left_bound = bookmark
+    elif from_block is None:
+        left_bound = None
     elif from_block == "latest":
         left_bound = -1
     elif from_block == "earliest":
@@ -145,7 +147,9 @@ def get_filter_bounds(from_block, to_block, bookmark=None):
     else:
         left_bound = from_block
 
-    if to_block == "latest":
+    if to_block is None:
+        right_bound = None
+    elif to_block == "latest":
         right_bound = None
     elif to_block == "earliest":
         right_bound = 1

--- a/eth_tester_client/utils.py
+++ b/eth_tester_client/utils.py
@@ -200,7 +200,9 @@ def mk_random_privkey():
 
 
 def is_valid_block_identifier(block_identifier):
-    if is_integer(block_identifier):
+    if block_identifier is None:
+        return True
+    elif is_integer(block_identifier):
         return True
     elif is_string(block_identifier):
         return force_text(block_identifier) in {"latest", "pending", "earliest"}


### PR DESCRIPTION
### What was wrong?

Small broken bits in the filter API

### How was it fixed?

Stop defaulting to `"latest"` for block numbers.

#### Cute Animal Picture

> put a cute animal picture here.

![article-2100198-11b18930000005dc-145_468x286](https://cloud.githubusercontent.com/assets/824194/18234602/58c87636-72c8-11e6-8e17-7656429cbb5b.jpg)
