### PR TITLE
allow specifying gas for transactions

### DIFF
--- a/eth_tester_client/client.py
+++ b/eth_tester_client/client.py
@@ -206,7 +206,15 @@ class EthTesterClient(object):
 
         data = decode_hex(data)
 
-        output = self.evm.send(sender=sender, to=to, value=value, evmdata=data)
+        try:
+            if gas is not None:
+                saved_gas_limit = t.gas_limit
+                t.gas_limit = gas
+            output = self.evm.send(sender=sender, to=to, value=value, evmdata=data)
+        finally:
+            if gas is not None:
+                t.gas_limit = saved_gas_limit
+
         return output
 
     #

--- a/eth_tester_client/client.py
+++ b/eth_tester_client/client.py
@@ -208,12 +208,10 @@ class EthTesterClient(object):
 
         try:
             if gas is not None:
-                saved_gas_limit = t.gas_limit
                 t.gas_limit = gas
             output = self.evm.send(sender=sender, to=to, value=value, evmdata=data)
         finally:
-            if gas is not None:
-                t.gas_limit = saved_gas_limit
+            t.gas_limit = t.GAS_LIMIT
 
         return output
 
@@ -261,7 +259,8 @@ class EthTesterClient(object):
         return self.send_transaction(
             _from=_from,
             to=to,
-            gas=tx.gasprice,
+            gas_price=tx.gasprice,
+            gas=tx.startgas,
             value=tx.value,
             data=data,
         )


### PR DESCRIPTION
### What was wrong?

The `gas` parameter was not respected when sending transactions.

### How was it fixed?

Added some voodoo monkeypatching to make the tester evm use the provided gas limit.

#### Cute Animal Picture

> put a cute animal picture here.

![article-0-1a4bb14c000005dc-554_634x429](https://cloud.githubusercontent.com/assets/824194/18885791/65f57e8c-84aa-11e6-8bd6-6f2f16e2e530.jpg)
