### PR TITLE
respect gas price as well

### DIFF
--- a/eth_tester_client/client.py
+++ b/eth_tester_client/client.py
@@ -209,9 +209,12 @@ class EthTesterClient(object):
         try:
             if gas is not None:
                 t.gas_limit = gas
+            if gas_price is not None:
+                t.gas_price = gas_price
             output = self.evm.send(sender=sender, to=to, value=value, evmdata=data)
         finally:
             t.gas_limit = t.GAS_LIMIT
+            t.gas_price = t.GAS_PRICE
 
         return output
 

--- a/tests/client/test_send_transaction.py
+++ b/tests/client/test_send_transaction.py
@@ -63,6 +63,25 @@ def test_can_specify_gas(client):
     assert tester.gas_limit == initial_tester_gas_limit
 
 
+def test_can_specify_gas_price(client):
+    kwargs = {
+        '_from': b'0x82a978b3f5962a5b0957d9ee9eef472ee55b42f1',
+        'to': b'0x82a978b3f5962a5b0957d9ee9eef472ee55b42f1',
+        'value': 1,
+        'gas_price': 1234,
+    }
+    initial_tester_gas_price = tester.gas_price
+
+    txn_hash = client.send_transaction(**kwargs)
+    assert txn_hash
+
+    txn = client.get_transaction_by_hash(txn_hash)
+    txn_gas_price = int(txn['gasPrice'], 16)
+    assert txn_gas_price != tester.gas_price
+    assert txn_gas_price == 1234
+    assert tester.gas_price == initial_tester_gas_price
+
+
 def test_deploying_contract(client, accounts):
     txn_hash = client.send_transaction(
         _from=accounts[0],


### PR DESCRIPTION
### What was wrong?

The `gasPrice` transaction parameter was not being respected.

### How was it fixed?

Monkeypatching the `tester` module.

#### Cute Animal Picture

> put a cute animal picture here.



