### PR TITLE
new_filter accepting hex-encoded 0x-based block numbers

### DIFF
--- a/eth_tester_client/client.py
+++ b/eth_tester_client/client.py
@@ -29,9 +29,8 @@ from .utils import (
     normalize_address,
     decode_hex,
     mk_random_privkey,
-    is_valid_block_identifier,
     is_array,
-)
+    normalize_block_identifier)
 from .serializers import (
     serialize_txn,
     serialize_txn_receipt,
@@ -383,10 +382,14 @@ class EthTesterClient(object):
         if address is None:
             address = []
 
-        if not is_valid_block_identifier(from_block):
+        try:
+            from_block = normalize_block_identifier(from_block)
+        except ValueError:
             raise ValueError("Invalid filter parameter for `from_block`")
 
-        if not is_valid_block_identifier(to_block):
+        try:
+            to_block = normalize_block_identifier(to_block)
+        except ValueError:
             raise ValueError("Invalid filter parameter for `to_block`")
 
         if is_string(address):

--- a/eth_tester_client/utils.py
+++ b/eth_tester_client/utils.py
@@ -199,12 +199,10 @@ def mk_random_privkey():
     return decode_hex(encode_number(random.getrandbits(256), 32))
 
 
-def is_valid_block_identifier(block_identifier):
+def normalize_block_identifier(block_identifier):
     if block_identifier is None:
-        return True
-    elif is_integer(block_identifier):
-        return True
-    elif is_string(block_identifier):
-        return force_text(block_identifier) in {"latest", "pending", "earliest"}
+        return None
+    elif block_identifier in ["latest", "earliest", "pending"]:
+        return block_identifier
     else:
-        raise TypeError("invalid type")
+        return normalize_number(block_identifier)

--- a/tests/filters/test_new_filter.py
+++ b/tests/filters/test_new_filter.py
@@ -25,6 +25,19 @@ def test_new_filter_with_single_no_args_event(client, call_emitter_contract,
     assert LogTopics.LogNoArguments in log_entry['topics']
 
 
+def test_new_filter_block_numbers_hex(client, call_emitter_contract,
+                                      Events, LogFunctions, LogTopics):
+    filter_id = client.new_filter(from_block="0x0", to_block="0x1", address=[], topics=[])
+
+    txn_hash = call_emitter_contract(LogFunctions.logNoArgs, [Events.LogNoArguments])
+
+    changes = client.get_filter_changes(filter_id)
+
+    assert len(changes) == 1
+    log_entry = changes[0]
+    assert LogTopics.LogNoArguments in log_entry['topics']
+
+
 def test_new_filter_with_anonymous_event(client, call_emitter_contract,
                                          LogFunctions, Events):
     filter_id = client.new_filter(from_block="earliest", to_block="latest", address=[], topics=[])


### PR DESCRIPTION
### What was wrong?
When `client.new_filter` receives a `from_block` or `to_block` in not-normalized form, it raises a ValueError, while `client.get_block_by_number` can process a not-normalized block number (this is an API inconsistency).


### How was it fixed?
`from_block` and `to_block` are being normalized, and the error is thrown if the normalization fails.


#### Cute Animal Picture

![sloth](http://media.mnn.com/assets/images/2015/02/sloth.jpg)

