### PR TITLE
After transaction fails, new block is not mined

### DIFF
--- a/eth_tester_client/client.py
+++ b/eth_tester_client/client.py
@@ -247,8 +247,10 @@ class EthTesterClient(object):
         return gas_used
 
     def send_transaction(self, *args, **kwargs):
-        self._send_transaction(*args, **kwargs)
-        self.mine_block()
+        try:
+            self._send_transaction(*args, **kwargs)
+        finally:
+            self.mine_block()
         return encode_32bytes(self.evm.last_tx.hash)
 
     def send_raw_transaction(self, raw_tx):


### PR DESCRIPTION
### What was wrong?
When `_send_transaction` raised an error (e.g. TransactionFailed raised in ethereum.tester), block's `gas_used` was being increased, but new block was not mined.


### How was it fixed?
By using python's `try.. finally` syntax.


#### Cute Animal Picture
![canary](http://jencasper.com/wp-content/uploads/2014/01/canary.jpg)

